### PR TITLE
db: MySQL configuration for PythonAnywhere

### DIFF
--- a/gsv/settings.py
+++ b/gsv/settings.py
@@ -92,8 +92,16 @@ WSGI_APPLICATION = 'gsv.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        # 'ENGINE': 'django.db.backends.sqlite3',
+        # 'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'zoetrope$sitedata',
+        'USER': os.getenv('DB_USER'),
+        'PASSWORD': os.getenv('DB_PASS'),
+        'HOST': 'zoetrope.mysql.pythonanywhere-services.com',
+        'TEST': {
+          'NAME': 'zoetrope$test_sitedata',
+        },
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-crispy-forms==1.14.0
 django-storages==1.13.1
 idna==3.4
 jmespath==1.0.1
+mysqlclient==2.1.1
 Pillow==9.3.0
 python-dateutil==2.8.2
 python-dotenv==0.21.0


### PR DESCRIPTION
Notes: this is hard to test locally due to the pythonanywhere firewall. There is a potential workaround using [manual ssh tunneling though](https://help.pythonanywhere.com/pages/AccessingMySQLFromOutsidePythonAnywhere)

You could also just switch the DATABASE config to the sqlite settings to run a local dev server, although I'm not sure about long-term support for this method.