### PR TITLE
adding google analytics tag to base html file

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-D50227P9TZ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-D50227P9TZ');
+    </script>
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
In order to use google analytics and track traffic we need to add a tag on each page. Resorted to add the tag to the `base.html` which seemed to be inherited by all other pages of the app.